### PR TITLE
Use string format methods

### DIFF
--- a/spandex/spatialtoolz.py
+++ b/spandex/spatialtoolz.py
@@ -430,5 +430,6 @@ def load_delimited_file(file_path, table_name, delimiter=',', append=False):
         exec_sql("CREATE TABLE {table} ({cols});".format(
             table=table_name, cols=columns))
     exec_sql("SET CLIENT_ENCODING='LATIN1';")
-    exec_sql("COPY {table} FROM '{file}' DELIMITER '{del}' CSV HEADER;".format(
-        table=table_name, file=file_path, del=delimiter))
+    exec_sql(
+        "COPY {table} FROM '{file}' DELIMITER '{delim}' CSV HEADER;".format(
+            table=table_name, file=file_path, delim=delimiter))


### PR DESCRIPTION
By using the string [.format() method](https://docs.python.org/2/library/stdtypes.html#str.format) we can take advantage of the new-ish [string formatting syntax](https://docs.python.org/2/library/string.html#format-string-syntax). This makes for somewhat more readable query strings, because instead of seeing a bunch of `%s` placeholders you can use named placeholders like `{table}` and `{col}`.

For example:

``` python
exec_sql(
    ("UPDATE {tname} "
     "SET {tfield} = (SELECT SUM(ST_Area(ST_Intersection({tname}.geom, {oname}.geom))) "
     "FROM {oname} "
     "WHERE ST_Intersects({tname}.geom, {oname}.geom)) / {tname}.calc_area;"
     ).format(
        tname=target_table_name, tfield=target_field,
        oname=overlapping_table_name))
```

Note also I'm using parentheses to write strings across multiple lines so that the queries don't have to go all on one line. You can break it up for readability. (Python basically ignores newlines within parentheses and brackets, and it'll concatenate separate strings it finds within parentheses.)
