### PR TITLE
Update Pandas requirement to 0.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=find_packages(exclude=['*.tests']),
     install_requires=[
         'GeoAlchemy2>=0.2.1',  # Bug fix for schemas other than public.
-        'pandas>=0.15.0',
+        'pandas>=0.15.0',      # pandas.Index.difference.
         'psycopg2>=2.5',       # connection and cursor context managers.
         'six>=1.4',            # Mapping for urllib.
         'SQLAlchemy>=0.8'      # GeoAlchemy2 support.


### PR DESCRIPTION
I made use of pandas.Index.difference a bit in my recent
PR (#46), which is available only in Pandas 0.15.
