### PR TITLE
sqlalchemy version to 0.9.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'pandas>=0.15.0',      # pandas.Index.difference.
         'psycopg2>=2.5',       # connection and cursor context managers.
         'six>=1.4',            # Mapping for urllib.
-        'SQLAlchemy==0.8'      # GeoAlchemy2 support.
+        'SQLAlchemy==0.9.9'      # GeoAlchemy2 support.
     ],
     extras_require={
         'gdal': ['GDAL>=1.7'],     # Python 3 support.


### PR DESCRIPTION
Versions of sqlalchemy between 0.8.7 and 0.9.9 work (test_io passes, and bayarea_urbansim data regen scripts run).  Version 1.0.0 (just released) and onwards  do not.  Version 0.8.0 and prior do not.
